### PR TITLE
Move to library code that makes selected data easier to read

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 The STIX visualization is meant to provide producers and consumers of STIX content with a rapid way to visualize the objects in a STIX JSON file, and the relationships between those objects. The visualization is implemented in HTML, CSS, and JavaScript (using the [D3.js](https://d3js.org/) library), and is suitable for standalone use — either on a hosted server or as a local file — or embedded into other applications. Regardless of how deployed, the JavaScript code in this repository does not transmit STIX data to any server; it is strictly processed within the browser in which the code is running, so it is suitable for data which the user does not wish to share.
 
-
-Visualizes STIX 2.0 content using d3. It's 100% browser-based, meaning that you can use it without sending all your data to the server (great!)
+It visualizes STIX 2.0 content using d3, and is 100% browser-based, meaning that you can use it without sending all your data to the server (great!)
 
 ### How does it work?
 
@@ -16,7 +15,7 @@ This code makes a lot of assumptions! It assumes:
 - Everything inside those arrays is an SDO, with an ID, type, and ideally title
 - One of those arrays contains a list of relationships between the other SDOs provided
 
-This should match most STIX 2.0 content inside a package. For a slightly out-of-date example, look at `test.json`.
+This should match most STIX 2.0 content inside a bundle. For a slightly out-of-date example, look at `test.json`.
 
 ### Neat, a graph! What next?
 

--- a/application.js
+++ b/application.js
@@ -112,24 +112,12 @@ function populateLegend(typeGroups) {
  * Takes datum as input
  * ******************************************************/
 function populateSelected(d) {
-  jsonString = JSON.stringify(d, replacer, 2); // get only the STIX values
-  purified = JSON.parse(jsonString); // make a new JSON object from the STIX values
-  
   // Remove old values from HTML
   selectedContainer.innerHTML = "";
   
   var counter = 0;
-  
-  Object.keys(purified).forEach(function(key) { // Make new HTML elements and display them
-    var keyString = key;
-    if (refRegex.exec(key)) { // key is "created_by_ref"... let's pretty that up
-      keyString = key.replace(/_(ref)?/g, " ").trim();
-    } else {
-      keyString = keyString.replace(/_/g, ' ');
-    }
-    keyString = keyString.charAt(0).toUpperCase() + keyString.substr(1).toLowerCase() // Capitalize it
-    keyString += ":";
-    
+
+  Object.keys(d).forEach(function(key) { // Make new HTML elements and display them
     // Create new, empty HTML elements to be filled and injected
     var div = document.createElement('div');
     var type = document.createElement('div');
@@ -142,22 +130,9 @@ function populateSelected(d) {
     type.classList.add("type");
     val.classList.add("value");
 
-    // Some of the potential values are not very readable (IDs
-    // and object references). Let's see if we can fix that.
-    var value = purified[key];
-    // Lots of assumptions being made about the structure of the JSON here...
-    if (Array.isArray(value)) {
-      value = value.join(", ")
-    } else if (typeof(value) === 'object') {
-      value = value.name;
-    } else if (/--/.exec(value) && !(keyString === "Id:")) {
-      if (!(idCache[value] === null || idCache[value] === undefined)) {
-        value = currentGraph.nodes[idCache[value]].name; // IDs are gross, so let's display something more readable if we can (unless it's actually the node id)
-      }
-    }
-
     // Add the text to the new inner html elements
-    type.innerText = keyString;
+    var value = d[key];
+    type.innerText = key;
     val.innerText = value;
     
     // Add new divs to "Selected Node"
@@ -185,18 +160,6 @@ function hideMessages() {
 function linkifyHeader() {
   var header = document.getElementById('header');
   header.classList.add('linkish');
-}
-
-/* ******************************************************
- * Screens out D3 chart data from the presentation.
- * Called as the 2nd parameter to JSON.stringify().
- * ******************************************************/
-function replacer(key, value) {
-  var blacklist = ["typeGroup", "index", "weight", "x", "y", "px", "py", "fixed", "dimmed"];
-  if (blacklist.indexOf(key) >= 0) {
-    return undefined;
-  }
-  return value;
 }
 
  /* *****************************************************


### PR DESCRIPTION
The moved code strips D3-specific data from a node before displaying it in the "Selected Node" area, as well as prettying up keys and values. Now this behavior is default when using the library and doesn't have to be implemented separately.