### PR TITLE
Add additional graph label customizability

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
       <button id="paste-parser">Parse</button>
       <br />
       <p>-- Configuration --</p>
-      <textarea id="paste-area-custom-config" name="pasted" placeholder="Copy/Paste, in JSON format, (if you want to specify this) your custom config for the graph as such: &#10;{&#10;&#34;object_type&#34;: &#10;&#9;{&#10;&#9;&#9;&#34;display_property&#34;: &#60;nameOfProperty&#62;, &#10;&#9;&#9;&#34;display_icon&#34;: &#60;nameOfIconFile&#62;&#10;&#9;}&#10;}&#10;&#10;Please note that the above properties are the only currently-supported customizations, and at least 1 of them has to be specified."></textarea>
+      <textarea id="paste-area-custom-config" name="pasted" placeholder="Copy/Paste, in JSON format, (if you want to specify this) your custom config for the graph as such: &#10;{&#10;&#34;&lt;object_type&gt;&#34;: &#10;&#9;{&#10;&#9;&#9;&#34;display_property&#34;: &#60;nameOfProperty&#62;, &#10;&#9;&#9;&#34;display_icon&#34;: &#60;nameOfIconFile&#62;&#10;&#9;},&#10;&quot;userLabels&quot;:&#10;&#9;{&#10;&#9;&#9;&quot;&lt;STIX ID&gt;&quot;: &quot;a label&quot;,&#10;&#9;&#9;...&#10;&#9;}&#10;}&#10;&#10;&quot;&lt;object_type&gt;&quot; lets you customize labels per-type; &quot;userLabels&quot; lets you customize labels per-ID.  For type-specific customization, please note that the above properties are the only currently-supported properties, and at least 1 of them has to be specified.  ID-specific label customization will take priority over type-specific labels."></textarea>
     </div>
     <div id="canvas-container" class="hidden">
       <div id="canvas-wrapper">

--- a/stix2viz/__init__.py
+++ b/stix2viz/__init__.py
@@ -1,11 +1,15 @@
 _COUNTER = 0
 
 
-def display(data, width=800, height=600):
+def display(data, config=None, width=800, height=600):
     """Display visualization in IPython notebook via the HTML display hook"""
 
     global _COUNTER
     from IPython.display import HTML
+
+    viz_args = [str(data).strip()]
+    if config:
+        viz_args.append(config)
 
     h = """
     <svg id='chart{id}' style="width:{width}px;height:{height}px;"></svg>
@@ -15,10 +19,15 @@ def display(data, width=800, height=600):
             chart = $('#chart{id}')[0];
             visualizer{id} = new stix2viz.Viz(chart, {{"width": {width}, "height": {height},
                 "iconDir": "/nbextensions/stix2viz/icons", "id": {id}}});
-            visualizer{id}.vizStix({data});
+            visualizer{id}.vizStix({args});
         }});
     </script>
-    """.format(id=_COUNTER, data=str(data).strip(), width=width, height=height)
+    """.format(
+        id=_COUNTER,
+        args=", ".join(viz_args),
+        width=width,
+        height=height
+    )
 
     _COUNTER += 1
     return HTML(h)

--- a/stix2viz/stix2viz/stix2viz.js
+++ b/stix2viz/stix2viz/stix2viz.js
@@ -133,16 +133,18 @@ define(["nbextensions/stix2viz/d3"], function(d3) {
         return;
       }
 
-      try {
-        if (typeof config === 'string' || config instanceof String) {
-          this.customConfig = JSON.parse(config);
-        } else if (config !== undefined) {
-          this.customConfig = config;
+      if (config) {
+        try {
+          if (typeof config === 'string' || config instanceof String) {
+            this.customConfig = JSON.parse(config);
+          } else {
+            this.customConfig = config;
+          }
+        } catch (err) {
+          alert("Something went wrong!\nThe custom config does not seem to be proper JSON.\nPlease fix or remove it and try again.\n\nError:\n" + err);
+          if (typeof onError !== 'undefined') onError();
+          return;
         }
-      } catch (err) {
-        alert("Something went wrong!\nThe custom config does not seem to be proper JSON.\nPlease fix or remove it and try again.\n\nError:\n" + err);
-        if (typeof onError !== 'undefined') onError();
-        return;
       }
 
       this.buildNodes(parsed);


### PR DESCRIPTION
This PR adds support for user-customized graph node labels, per STIX ID.  (The pre-existing customizability was per-type.)  It also adds support in the Jupyter support `display()` function for passing config settings.  This allows config settings to be passed into stix2viz from python.

(These capabilities will be used in the STIX prototyping language Jupyter notebook documentation, to make graphs more understandable, and easier to align to language statements.)