### PR TITLE
Reworked display to allow object details via JSON.  Added link view.

### DIFF
--- a/application.css
+++ b/application.css
@@ -5,6 +5,12 @@ html, body {
   font-weight: 300;
 }
 
+ul li div {
+  height: 37px;
+  display: inline-block;
+  vertical-align: middle;
+}
+
 h1 {
   font-size: 36px;
   font-weight: 300;
@@ -28,10 +34,13 @@ h1 img {
   bottom: 0;
   left: 0;
   right: 0;
+  padding-bottom: 25px;
+  width: auto;
 }
 
 svg {
   border: solid 1px black;
+  width: auto;
 }
 
 #uploader {
@@ -53,6 +62,7 @@ svg {
 #canvas-wrapper {
   margin: 25px;
   float: left;
+  width: auto;
 }
 
 .sidebar {
@@ -74,31 +84,65 @@ svg {
 
 #selected {
   margin-top: 25px;
-  padding: 25px;
   background-color: #fafafa;
   cursor: pointer;
+  float: left;
+  width: 50%;
 }
 
-#selection > div {
-  padding: .5em 0 .5em 2%;
+#linkedNodesGroup {
+  margin-top: 25px;
+  background-color: #fafafa;
+  cursor: pointer;
+  float: right;
+  width: 50%;
 }
 
-#selection > .odd {
-  background-color: #e5e5e5;
+div.top-wrapper {
+  display: table-row;
+  width: 100%;
 }
 
-#selection > div > div {
-  display: inline-block;
-  vertical-align: top;
-}
-
-#selection > div > .type {
+div.wrapper > div > .type {
   width: 30%;
   font-weight: bold;
 }
 
-#selection > div > .value {
-  width: 65%;
+div.wrapper {
+  margin-left: 2em;
+  width: 100%;
+  overflow-wrap: break-word;
+  display: inline-block;
+}
+
+span.title {
+  font-weight: normal;
+  color: purple;
+}
+
+span.num_value {
+  color: orange;
+  cursor: text;
+}
+
+span.text_value {
+  color: darkblue;
+  cursor: text;
+}
+
+span.ref_value_resolved {
+  color: lightblue;
+  text-decoration: underline;
+  cursor: context-menu;
+}
+
+span.ref_value_unresolved {
+  color: red;
+  text-decoration: underline;
+  cursor: not-allowed;
+}
+
+div.wrapper > div > .value {
   word-wrap: break-word;
 }
 
@@ -133,20 +177,10 @@ li {
   margin: 0;
 }
 
-ul li div {
-  width: 37px;
-  height: 37px;
-  display: inline-block;
-  vertical-align: middle;
-}
 
 ul > li > p {
   display: inline-block;
   margin: 5px 10px;
-}
-
-pre {
-  white-space: pre-wrap;
 }
 
 .dimmed {

--- a/index.html
+++ b/index.html
@@ -18,16 +18,16 @@
     <a href="https://github.com/oasis-open/cti-stix-visualization/"><img src="GitHub-Mark-64px.png" alt="View source on GitHub"></a></h1>
 
     <div id="uploader">
-      <p>Drop some STIX 2.0 here!</p>
+      <p>Drop some STIX 2.x here!</p>
       <input type="file" id="files" name="files" /><br>
       <p>-- OR --</p>
-      <p>Fetch some STIX 2.0 from this URL!</p>
+      <p>Fetch some STIX 2.x from this URL!</p>
       <input type="text" id="url" name="url" placeholder="Paste URL here" /><br>
       <button id="fetch-url">Fetch</button>
       <p>-- OR --</p>
       <p>Pass it as a url parameter, like so:</p><a href="https://oasis-open.github.io/cti-stix-visualization/?url=https://raw.githubusercontent.com/oasis-open/cti-stix-visualization/master/test.json">https://oasis-open.github.io/cti-stix-visualization/?url=https://raw.githubusercontent.com/oasis-open/cti-stix-visualization/master/test.json</a>
       <p>-- OR --</p>
-      <p>Paste some STIX 2.0 here!</p>
+      <p>Paste some STIX 2.x here!</p>
       <textarea id="paste-area-stix-json" name="pasted" placeholder="Copy/Paste JSON data here..."></textarea><br>
       <button id="paste-parser">Parse</button>
       <br />
@@ -35,21 +35,34 @@
       <textarea id="paste-area-custom-config" name="pasted" placeholder="Copy/Paste, in JSON format, (if you want to specify this) your custom config for the graph as such: &#10;{&#10;&#34;&lt;object_type&gt;&#34;: &#10;&#9;{&#10;&#9;&#9;&#34;display_property&#34;: &#60;nameOfProperty&#62;, &#10;&#9;&#9;&#34;display_icon&#34;: &#60;nameOfIconFile&#62;&#10;&#9;},&#10;&quot;userLabels&quot;:&#10;&#9;{&#10;&#9;&#9;&quot;&lt;STIX ID&gt;&quot;: &quot;a label&quot;,&#10;&#9;&#9;...&#10;&#9;}&#10;}&#10;&#10;&quot;&lt;object_type&gt;&quot; lets you customize labels per-type; &quot;userLabels&quot; lets you customize labels per-ID.  For type-specific customization, please note that the above properties are the only currently-supported properties, and at least 1 of them has to be specified.  ID-specific label customization will take priority over type-specific labels."></textarea>
     </div>
     <div id="canvas-container" class="hidden">
-      <div id="canvas-wrapper">
-        <svg id="canvas"></svg>
-        <p>Nodes are draggable! (Node will 'pin' on mouseup)</p>
-        <p>Double-click a pinned node to unpin it!</p>
-        <p>Click the 'Selected Node' area to expand/shrink it.</p>
-      </div>
-      <div id="legend" class="sidebar">
-        <h2>Legend</h2>
-        <ul id="legend-content"></ul>
-      </div>
-      <div id="selected" class="sidebar">
-        <h2>Selected Node</h2>
-        <div id="selection">
+      <div id="canvas-group" class="top-wrapper">
+        <div id="canvas-wrapper">
+          <svg id="canvas"></svg>
+          <p>Nodes are draggable! (Node will 'pin' on mouseup)</p>
+          <p>Double-click a pinned node to unpin it!</p>
+        </div>
+        <div id="legend" class="sidebar">
+          <h2>Legend</h2>
+          <ul id="legend-content"></ul>
         </div>
       </div>
+      <form name="mainList">
+        <div id="simple-list-container" class="hidden top-wrapper">
+          <ol id="simple-list"></ol>
+        </div>
+        <div class="top-wrapper">
+          <div id="selected">
+            <h2>Selected Node</h2>
+            <div id="selection">
+            </div>
+          </div>
+          <div id="linkedNodesGroup">
+            <h2>Linked Nodes</h2>
+            <div id="linkedNodes">
+            </div>
+          </div>
+        </div>
+    </form>
     </div>
   </body>
 </html>


### PR DESCRIPTION
1. Added a class of objects that can be hidden from the graph if certain filter conditions are met such as malware-analysis objects that have no analysis_sco_refs as these become cluttered on the graph when running a large number of AV tools.
1. Node details now display as a JSON like format and show all nested content instead of in a table.
1. A full list of linked objects is now displayed along with node details for the selected node.
1. Selections can be changed using these detailed lists.
1. _ref and _refs values are now color coded based on if the reference is within the provided JSON.
1. If a graph has more than 200 elements it gives an option to show it as a list instead.